### PR TITLE
Prefix the saved as path with a period

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/gui/quests/EditSettingsButton.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/gui/quests/EditSettingsButton.java
@@ -61,7 +61,7 @@ public class EditSettingsButton extends TabButton {
 				appendNum(fileName, time.get(Calendar.SECOND), '\0');
 				File file = new File(Minecraft.getInstance().gameDirectory, fileName.toString()).getCanonicalFile();
 				ClientQuestFile.INSTANCE.writeDataFull(file.toPath());
-				Component component = new TranslatableComponent("ftbquests.gui.saved_as_file", file.getPath().replace(Minecraft.getInstance().gameDirectory.getCanonicalFile().getAbsolutePath(), ""));
+				Component component = new TranslatableComponent("ftbquests.gui.saved_as_file", "." + file.getPath().replace(Minecraft.getInstance().gameDirectory.getCanonicalFile().getAbsolutePath(), ""));
 				component.getStyle().withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, file.getAbsolutePath()));
 				Minecraft.getInstance().player.sendMessage(component, Util.NIL_UUID);
 			} catch (Exception ex) {


### PR DESCRIPTION
Currently it implies being saved on the root of the filesystem, instead of within the minecraft instance's directory.

![Screen Shot 2021-10-26 at 10 59 46](https://user-images.githubusercontent.com/3179271/138846158-500b86b0-b6b1-4ae6-aeec-fe37217db930.png)

