### PR TITLE
fix: fixed a crash when switching dimensions.

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/quest/task/ObservationTask.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/quest/task/ObservationTask.java
@@ -132,6 +132,10 @@ public class ObservationTask extends AbstractBooleanTask {
 			BlockInWorld blockInWorld = new BlockInWorld(player.level(), blockResult.getBlockPos(), false);
 
 			BlockState state = blockInWorld.getState();
+			if (state == null) {
+				return false;
+			}
+
 			Block block = state.getBlock();
 			BlockEntity blockEntity = blockInWorld.getEntity();
 


### PR DESCRIPTION
While playing All the Mods 9 it liked to randomly crash when switching dimensions.
Apparently the `BlockState` returned by `BlockInWorld.getState()` can be null and because of this I just added a null check.