### PR TITLE
fix: progression blocking in flexible quests

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/quest/ServerQuestFile.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/quest/ServerQuestFile.java
@@ -209,11 +209,15 @@ public class ServerQuestFile extends BaseQuestFile {
 				Date now = new Date();
 				PlayerInventorySummary.build(player);
 				forAllQuests(quest -> {
+					if (!data.isCompleted(quest) && quest.getProgressionMode() == ProgressionMode.FLEXIBLE && data.areDependenciesComplete(quest)) {
+						for (Task task : quest.getTasks()) {
+							if (!data.isCompleted(task) && data.getProgress(task) >= task.getMaxProgress()) {
+								data.markTaskCompleted(task);
+							}
+						}
+					}
+
 					if (!data.isCompleted(quest) && quest.isCompletedRaw(data)) {
-						// Handles possible situation where quest book has been modified to remove a task from a quest
-						// It can leave a player having completed all the other tasks, but unable to complete the quest
-						//   since quests are normally marked completed when the last task in that quest is completed
-						// https://github.com/FTBBeta/Beta-Testing-Issues/issues/755
 						quest.onCompleted(new QuestProgressEventData<>(now, data, quest, onlineMembers, pList));
 					}
 


### PR DESCRIPTION
Ensures that tasks within quests using flexible progression mode are correctly finalized once they reach maximum progress. This prevents situations where a quest could become stuck even when all task requirements were met.